### PR TITLE
Make Cache<T>.Instance static

### DIFF
--- a/1.md
+++ b/1.md
@@ -184,7 +184,7 @@ public class MyDependencyFactory
 
 ## Caching singletons in generic types
 
-If you need to cache an instance of something based on type, then you can store it on the field of a generic type. 
+If you need to cache an instance of something based on type, then you can store it on a static field of a generic type.
 
 ```C#
 public class Factory
@@ -194,9 +194,9 @@ public class Factory
         return Cache<T>.Instance;
     }
     
-    private class Cache<T>
+    private static class Cache<T>
     {
-        public T Instance = new T();
+        public static T Instance = new T();
     }
 }
 ```
@@ -211,11 +211,11 @@ public class Factory
         return Cache<T>.Instance;
     }
     
-    private class Cache<T>
+    private static class Cache<T>
     {
-        public T Instance = CallExpensiveMethodToBuildANewInstance();
+        public static T Instance = CallExpensiveMethodToBuildANewInstance();
         
-        public T CallExpensiveMethodToBuildANewInstance()
+        public static T CallExpensiveMethodToBuildANewInstance()
         {
             // Imagine a really complex process to construct T
             return instance.


### PR DESCRIPTION
The `Instance` property of `Cache<T>` should be static in order to access the property by its type.