### PR TITLE
Add service provider field in MyDependencyFactory

### DIFF
--- a/1.md
+++ b/1.md
@@ -45,7 +45,7 @@ Sometimes it's necessary to create services later than a constructor. The usuall
 ```C#
 public class Service
 {
-    private IServiceProvider _serviceProvider;
+    private readonly IServiceProvider _serviceProvider;
     public void Something(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
@@ -150,10 +150,10 @@ public class MyDependency
 ```C#
 public class MyDependencyFactory
 {
-    private IServiceProvider _serviceProvider;
+    private readonly IServiceProvider _serviceProvider;
     public MyDependencyFactory(IServiceProvider serviceProvider)
     {
-        _serviceProvider = serviceProvider
+        _serviceProvider = serviceProvider;
     }
     public MyDependency GetInstance()
     {
@@ -168,9 +168,11 @@ based on the types passed and build a factory for it.
 ```C#
 public class MyDependencyFactory
 {
-    private ObjectFactory _factory;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ObjectFactory _factory;
     public MyDependencyFactory(IServiceProvider serviceProvider)
     {
+        _serviceProvider = serviceProvider;
         _factory = ActivatorUtilities.CreateFactory(typeof(MyDependency), Type.EmptyTypes);
     }
     public MyDependency GetInstance()


### PR DESCRIPTION
Store the service provider in a field in order to make the `MyDependencyFactory.GetInstance` method work.

Also fixes a missing semicolon, and makes the `IServiceProvider` fields readonly.

This also fixes #2.